### PR TITLE
Removing the black background from banner

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -9493,7 +9493,6 @@ body.home section.splash .intro-message {
 body.home section.splash .intro-message .splash-title,
 body.home section.splash .intro-message .splash-subtitle {
   font-family: "QuarkBold", Helvetica, Arial, sans-serif;
-  background: rgba(0, 0, 0, 0.7);
   padding: 10px;
   text-shadow: 2px 2px 3px rgba(0, 0, 0, 0.9);
   color: #fff;


### PR DESCRIPTION
The text has a shadow (which is not visible here), and without the
black boxy background it looks more integrated with dashboard style -
which has similar text and image but no black background.